### PR TITLE
Add operation enums

### DIFF
--- a/src/vertex.ts
+++ b/src/vertex.ts
@@ -29,6 +29,30 @@ export enum VertexKind {
     Call = 'Call',
 }
 
+export enum BinaryOperation {
+    Add = '+',
+    Sub = '-',
+    Mul = '*',
+    Div = '/',
+    Assign = '=',
+    LessThan = '<',
+    GreaterThan = '>',
+    LessThanEqual = '<=',
+    GreaterThanEqual = '>=',
+    EqualEqual = '==',
+    NotEqual = '!=',
+    EqualEqualEqual = '===',
+    NotEqualEqual = '!==',
+    And = '&&',
+    Or = '||'
+}
+
+export enum UnaryOperation {
+    Plus = '+',
+    Minus = '-',
+    Not = '!'
+}
+
 export abstract class Vertex {
     /*@internal*/
     private _id: number = -1;


### PR DESCRIPTION
I hesitated between creating a new "operations.ts" file for these enums, and adding them to vertex.ts. The first option didn't work (Module '"graphir"' has no exported member 'BinaryOperation'). Maybe I will change it later